### PR TITLE
Add tmpPath option and autoRemove

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,19 @@ The full options object is as follows:
   type: 'jpg',
   logLevel: 1,
   prefix: 'page',
-  suffix: '_foo'
+  suffix: '_foo',
+  tmpPath: '/path/to/tmp',
+  autoRemoveTmp: true
 }
 ```
-| Option   | Default | Description                                                                                                                 |
-|----------|---------|-----------------------------------------------------------------------------------------------------------------------------|
-| type     | 'png'   | The file type of the converted files                                                                                        |
-| logLevel | 0       | The level of the logs required. 0: Errors only, 1: Information                                                              |
-| prefix   | 'page'  | The string that will be prepended to the file names of the pages converted. E.g. 'page': page1.png                          |
-| suffix   | ''      | The string that will be appended onto the end of the file names of the page converted. E.g. '_invoices': page1_invoices.png |
+| Option        | Default | Description                                                                                                                 |
+|---------------|---------|-----------------------------------------------------------------------------------------------------------------------------|
+| type          | 'png'   | The file type of the converted files                                                                                        |
+| logLevel      | 0       | The level of the logs required. 0: Errors only, 1: Information                                                              |
+| prefix        | 'page'  | The string that will be prepended to the file names of the pages converted. E.g. 'page': page1.png                          |
+| suffix        | ''      | The string that will be appended onto the end of the file names of the page converted. E.g. '_invoices': page1_invoices.png |
+| tmpPath       | null    | Overwrites the Imagemagick default tmp directory path                                                                       |
+| autoRemoveTmp | false   | Automatically removes all files from tmpPath prefixed with magick-*, this happens on process completion                     |
 
 ## Callbacks
 There are 2 available callbacks to allow you to create actions on the success of individual conversions and when the queue is complete.

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -7,6 +7,8 @@ var childProcess = require('child_process'),
  * page: 'A4', 'A3'
  * type: 'png', 'jpg'
  * logLevel: 1 = info, 0, error (default)
+ * tmpPath: '/path/to/tmp' (optional),
+ * autoRemoveTmp: true, false (default)
  */
 
 var TiffConverter = function(options){
@@ -18,6 +20,10 @@ var TiffConverter = function(options){
   _this.tiffs = [];
   _this.options = options;
   _this.errors = [];
+
+  if (options) {
+    _this.options.autoRemoveTmp =  options.autoRemoveTmp || false;
+  }
 
   /**
    * Callback to show the amount converted.
@@ -75,7 +81,15 @@ TiffConverter.prototype.convert = function(){
 
     if(err) logger.error(err);
 
-    childProcess.exec('convert ' + original + ' -scene 1 ' + target + '/' + prefix + '%d' + suffix + '.' + type, function(err, stdout, stderr){
+    var command = 'convert';
+
+    if (_this.options.tmpPath) {
+      command += ' -define registry:temporary-path=' + _this.options.tmpPath;
+    }
+
+    command += ' ' + original + ' -scene 1 ' + target + '/' + prefix + '%d' + suffix + '.' + type;
+
+    childProcess.exec(command, function(err, stdout, stderr){
 
       if(err){
         logger.tabbed('Conversion failed', false);
@@ -106,6 +120,19 @@ TiffConverter.prototype.convert = function(){
           _this.errors.forEach(function(error){
             logger.debugError(error.target, error.error);
             logger.space();
+          });
+        }
+
+        // Process complete, if there is a tmpPath set, remove any files
+        if (_this.options.tmpPath && _this.options.autoRemoveTmp) {
+          fs.readdir(_this.options.tmpPath, function(err, files) {
+            if (err) logger.error(err);
+            files.forEach(function(file) {
+              var pattern = new RegExp('magick-');
+              if (pattern.test(file)) {
+                fs.unlink(_this.options.tmpPath + '/' + file);
+              }
+            });
           });
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiff-to-png",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A batch converter for multipage tiff files to png (or any imagemagick supported type).",
   "main": "./lib/convert.js",
   "scripts": {


### PR DESCRIPTION
Resolves #2 by allowing the user to manually set a tmp folder, then giving the option to auto remove all 'magick-' prefixed files. This TMP issue seems to be a common issue with imagemagick when it doesn't get the chance to clear the `/tmp` directory on successfully completing large files or large batches.

This solution seems to be the best practice for a workaround.