### PR TITLE
Adds saveFolder option

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -74,7 +74,7 @@ TiffConverter.prototype.convert = function(){
 
   var filenameRegex = new RegExp('([^\\|\/]*(?=[.][a-zA-Z]+$))', 'g'),
     filename = original.match(filenameRegex)[0];
-    target = _this.location + '/' + filename;
+    target = _this.options.saveFolder ? _this.location + '/' + _this.options.saveFolder : _this.location + '/' + filename;
 
   // Create the director
   _this.createDir(target, filename, function(err){


### PR DESCRIPTION
Adds saveFolder option to allow for naming of subfolder instead of using the filename.

this just adds the ability to have all your files saved under the folder name in addition to the parent directory.

I didn't like that my folders were automatically being named the same as the files that were converted.
